### PR TITLE
Tweak rule set

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -42,6 +42,9 @@
     // enforce a maximum cyclomatic complexity allowed in a program
     "complexity": [1, 6],
 
+    // require return statements to either always or never specify values
+    "consistent-return"          : [2],
+
     // enforce consistent brace style for all control statements
     "curly": [2],
 
@@ -50,6 +53,9 @@
 
     // enforce dot notation whenever possible
     "dot-notation": [2],
+
+    // require or disallow newline at the end of files
+    "eol-last": [2],
 
     // require or disallow spacing between function identifiers and their invocations
     "func-call-spacing": [2, "never"],
@@ -73,7 +79,7 @@
     "max-depth": [2, 3],
 
     // enforce a maximum line length
-    "max-len": [2, { "code": 80 }],
+    "max-len": [2, { "code": 120, "comments": 80 }],
 
     // require an empty line before return statements
     "newline-before-return": [2],
@@ -117,6 +123,9 @@
     // disallow variable or function declarations in nested blocks
     "no-inner-declarations": [2],
 
+    // Disallow this keywords outside of classes or class-like objects.
+    "no-invalid-this"            : [2],
+
     // disallow the use of the __iterator__ property
     "no-iterator": [2],
 
@@ -130,7 +139,7 @@
     "no-mixed-spaces-and-tabs": [2, "smart-tabs"],
 
     // disallow multiple empty lines
-    "no-multiple-empty-lines": [2, { "max": 1 }],
+    "no-multiple-empty-lines": [2, { "max": 3 }],
 
     // disallow nested ternary expressions
     "no-nested-ternary": [2],
@@ -153,6 +162,12 @@
     // disallow comparisons where both sides are exactly the same
     "no-self-compare": [2],
 
+    // Disallow Shadowing of Restricted Names
+    "no-shadow-restricted-names": [2],
+
+    // Disallow Initializing to undefined
+    "no-undef-init": [2],
+
     // disallow unmodified loop conditions
     "no-unmodified-loop-condition": [2],
 
@@ -164,6 +179,9 @@
 
     // disallow unused variables
     "no-unused-vars": [2, { "args": "none" }],
+
+    // Disallow Early Use
+    "no-use-before-define": [2, { "functions": false }],
 
     // disallow unnecessary calls to .call() and .apply()
     "no-useless-call": [2],
@@ -191,6 +209,9 @@
 
     // require JSDoc comments
     "require-jsdoc": [2],
+
+    // require or disallow semicolons instead of ASI
+    "semi": [ 2, "always" ],
 
     // require or disallow strict mode directives
     "strict": [2, "function"]


### PR DESCRIPTION
Added rules which I think add value:
- consistent-returns
- eol-last
- no-invalid-this
- no-shadow-restricted-names
- no-undef-init
- no-use-before-define
- semi

The following rules where adjusted:
- max-len: allow code to 120 chars per line, make sure comments don't exceed 80 chars
- no-multiple-empty-lines: increased the max from 1 to 3. This will allow you to create "regions" of code.